### PR TITLE
chore(deps): add 7-day Dependabot cooldown (PTFM-18885) [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,3 @@
-
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
@@ -10,3 +9,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
Adds `cooldown: { default-days: 7 }` to every `package-ecosystem` block in `.github/dependabot.yml`.

## Why
Mitigates supply-chain attacks where a malicious version is published, detected, and yanked within hours/days — without cooldown, Dependabot can open a PR for the malicious version before it is pulled.

## Skip-CI
Title carries `[skip ci]` so merging this PR does not trigger CI/CD on the default branch.

## Jira
[PTFM-18885](https://kpler.atlassian.net/browse/PTFM-18885)


[PTFM-18885]: https://kpler.atlassian.net/browse/PTFM-18885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ