### PR TITLE
chore(ci): SHA-pin third-party Actions (PTFM-18886) [skip ci]

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4  # v4
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4  # v4
         with:
           go-version-file: go.mod
           check-latest: true
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
 
       - name: Check that docs were generated
         run: make check-docs
@@ -36,16 +36,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4  # v4
         with:
           go-version-file: go.mod
           check-latest: true
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
 
       - name: Run tests
         run: make test-acc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4  # v4
         with:
           go-version-file: go.mod
           check-latest: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ jobs:
     # Skip any PR created by dependabot to avoid permission issues
     if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
       - run: semgrep ci
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_TOKEN }}

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4  # v4
         with:
           go-version-file: go.mod
           check-latest: true


### PR DESCRIPTION
## Summary
SHA-pinned external GitHub Actions referenced by tag. For each `uses: foo/bar@v4`, replaced with `uses: foo/bar@<sha>  # v4`.

## Why
Tags are mutable. A compromised maintainer can re-point a tag (e.g. `v4`) to a malicious commit retroactively, even after we've reviewed and trusted the code at that tag. A SHA is immutable. The version comment keeps the line readable, and Dependabot bumps both the SHA and the comment together as new versions ship.

See [Confluence: GitHub Actions Best Practices & Recommendations / Security recommendations](https://kpler.atlassian.net/wiki/spaces/KSD/pages/243541590/GitHub+Actions+Best+Practices+Recommendations) for the rationale.

## Scope
- All `uses:` references are pinned, including internal `Kpler/*` actions. Dependabot will keep the SHA + version comment in sync as new versions ship.
- Local action references (`./...`) are not touched.
- Inline package installs (`pip install`, `uv add`, `apt install`, etc.) inside workflow scripts are intentionally OUT OF SCOPE for this PR and will be handled in a separate follow-up rollout.

## Skip-CI
Title and commit body carry `[skip ci]` so merging this PR does not trigger CI/CD on the default branch.

## Jira
[PTFM-18886](https://kpler.atlassian.net/browse/PTFM-18886)


[PTFM-18886]: https://kpler.atlassian.net/browse/PTFM-18886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ